### PR TITLE
ci: remove expressions.tests.FTimeDeltaTests.test_mixed_comparisons1 from expected failures

### DIFF
--- a/django_cockroachdb/creation.py
+++ b/django_cockroachdb/creation.py
@@ -284,7 +284,6 @@ class DatabaseCreation(PostgresDatabaseCreation):
             # Incorrect interval math on date columns when a time zone is set:
             # https://github.com/cockroachdb/django-cockroachdb/issues/53
             'expressions.tests.FTimeDeltaTests.test_date_comparison',
-            'expressions.tests.FTimeDeltaTests.test_mixed_comparisons1',
             # Interval math across dst works differently from other databases.
             # https://github.com/cockroachdb/django-cockroachdb/issues/54
             'expressions.tests.FTimeDeltaTests.test_delta_update',


### PR DESCRIPTION
Possibly this test started passing after we passed the end of daylight
savings time last week. Investigate if the failure returns.