### PR TITLE
ci: install Django before django_cockroachdb

### DIFF
--- a/teamcity-build/build-teamcity.sh
+++ b/teamcity-build/build-teamcity.sh
@@ -4,10 +4,6 @@ set -x
 # Set an environment variable used by cockroach/django/creation.py.
 export RUNNING_COCKROACH_BACKEND_TESTS=1
 
-# install the django-cockroachdb backend.
-pip3 install psycopg2-binary
-pip3 install .
-
 # clone django into the repo.
 git clone --depth 1 --single-branch --branch cockroach-2.2.x https://github.com/timgraham/django _django_repo
 
@@ -16,12 +12,18 @@ cd _django_repo/tests/
 pip3 install -e ..
 pip3 install -r requirements/py3.txt
 pip3 install -r requirements/postgres.txt
+cd ../..
+
+# install the django-cockroachdb backend.
+pip3 install .
 
 # download and start cockroach
 wget "https://binaries.cockroachdb.com/cockroach-v19.2.0.linux-amd64.tgz"
 tar -xvf cockroach-v19.2*
 cp cockroach-v19.2*/cockroach cockroach_exec
 ./cockroach_exec start --insecure &
+
+cd _django_repo/tests/
 
 # Bring in the settings needed to run the tests with cockroach.
 cp ../../teamcity-build/cockroach_settings.py .


### PR DESCRIPTION
Importing `__version__` in setup.py (76fdb38c44f87830c127638fb4d946bee12b9573) causes `ModuleNotFoundError` if Django isn't already installed.