### PR TITLE
use integer data type with DEFAULT expression for BigAutoField

### DIFF
--- a/django_cockroachdb/base.py
+++ b/django_cockroachdb/base.py
@@ -19,11 +19,13 @@ class DatabaseWrapper(PostgresDatabaseWrapper):
     # Override some types from the postgresql adapter.
     data_types = dict(
         PostgresDatabaseWrapper.data_types,
+        BigAutoField='integer',
         AutoField='integer',
         DateTimeField='timestamptz',
     )
     data_types_suffix = dict(
         PostgresDatabaseWrapper.data_types_suffix,
+        BigAutoField='DEFAULT unique_rowid()',
         AutoField='DEFAULT unique_rowid()',
     )
 


### PR DESCRIPTION
It's equivalent to bigserial, but the CockroachDB docs explain,
"SERIAL is provided only for compatibility with PostgreSQL. New applications
should use real data types and a suitable DEFAULT expression."