### PR TITLE
add Django version compatibility check

### DIFF
--- a/django_cockroachdb/__init__.py
+++ b/django_cockroachdb/__init__.py
@@ -1,5 +1,7 @@
 from .functions import register_functions
+from .utils import check_django_compatability
 
 __version__ = '3.0a1'
 
+check_django_compatability()
 register_functions()

--- a/django_cockroachdb/utils.py
+++ b/django_cockroachdb/utils.py
@@ -1,7 +1,28 @@
+import django
+from django.core.exceptions import ImproperlyConfigured
 from django.utils.timezone import get_fixed_timezone, utc
+from django.utils.version import get_version_tuple
 
 
 def utc_tzinfo_factory(offset):
     if offset != 0:
         return get_fixed_timezone(offset)
     return utc
+
+
+def check_django_compatability():
+    """
+    Verify that this version of django-cockroachdb is compatible with the
+    installed version of Django. For example, any django-cockroachdb 2.2.x is
+    compatible with Django 2.2.y.
+    """
+    from . import __version__
+    if django.VERSION[:2] != get_version_tuple(__version__)[:2]:
+        raise ImproperlyConfigured(
+            'You must use the latest version of django-cockroachdb {A}.{B}.x '
+            'with Django {A}.{B}.y (found django-cockroachdb {C}).'.format(
+                A=django.VERSION[0],
+                B=django.VERSION[1],
+                C=__version__,
+            )
+        )


### PR DESCRIPTION
An example error message is: `django.core.exceptions.ImproperlyConfigured: You must use the latest version of django-cockroachdb 2.2.x with Django 2.2.y (found django-cockroachdb 3.0a1).`