### PR TITLE
make DatabaseIntrospection.get_table_list() compatible with CockroachDB 20.2

### DIFF
--- a/django_cockroachdb/introspection.py
+++ b/django_cockroachdb/introspection.py
@@ -7,10 +7,10 @@ from django.db.models import Index
 
 class DatabaseIntrospection(PostgresDatabaseIntrospection):
     data_types_reverse = dict(PostgresDatabaseIntrospection.data_types_reverse)
-    data_types_reverse[1184] = 'DateTimeField'  # TIMESTAMPZ
+    data_types_reverse[1184] = 'DateTimeField'  # TIMESTAMPTZ
 
     def get_table_list(self, cursor):
-        cursor.execute("SHOW TABLES")
+        cursor.execute("SELECT table_name FROM [SHOW TABLES]")
         # The second TableInfo field is 't' for table or 'v' for view.
         return [TableInfo(row[0], 't') for row in cursor.fetchall()]
 


### PR DESCRIPTION
* Refs https://github.com/cockroachdb/cockroach/issues/46553
* Refs https://github.com/cockroachdb/cockroach/pull/46598

In 20.2, we're investigating putting more columns into SHOW TABLES. As
such, this query will need to update in a backwards compatible way. The
query has thus been modified to support both old and new versions.