### PR TITLE
Remove psycopg2 installation requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 3.0.1 - Unreleased
 
 - Add support for `QuerySet.explain()` options.
+- Remove `psycopg2` from `setup.py`'s `install_requires` so that users can
+  install either `psycopg2` or `psycopg2-binary`.
 
 ## 3.0 - 2020-01-15
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # CockroachDB backend for Django
 
+## Prerequisites
+
+You must install either:
+
+* [psycopg2](https://pypi.org/project/psycopg2/), which has some
+  [prerequisites](https://www.psycopg.org/docs/install.html#prerequisites) of
+  its own.
+
+* [psycopg2-binary](https://pypi.org/project/psycopg2-binary/)
+
+The binary package is a practical choice for development and testing but in
+production it is advised to use the package built from sources.
+
 ## Install and usage
 
 Use the version of django-cockroachdb that corresponds to your version of

--- a/django_cockroachdb/base.py
+++ b/django_cockroachdb/base.py
@@ -1,15 +1,27 @@
 from django.conf import settings
-from django.db.backends.postgresql.base import (
+from django.core.exceptions import ImproperlyConfigured
+
+try:
+    import psycopg2  # noqa
+    import psycopg2.extensions  # noqa
+    import psycopg2.extras  # noqa
+except ImportError as err:
+    raise ImproperlyConfigured(
+        'Error loading psycopg2 module.\n'
+        'Did you install psycopg2 or psycopg2-binary?'
+    ) from err
+
+from django.db.backends.postgresql.base import (    # isort:skip
     DatabaseWrapper as PostgresDatabaseWrapper,
 )
 
-from .client import DatabaseClient
-from .creation import DatabaseCreation
-from .features import DatabaseFeatures
-from .introspection import DatabaseIntrospection
-from .operations import DatabaseOperations
-from .schema import DatabaseSchemaEditor
-from .utils import utc_tzinfo_factory
+from .client import DatabaseClient                  # isort:skip
+from .creation import DatabaseCreation              # isort:skip
+from .features import DatabaseFeatures              # isort:skip
+from .introspection import DatabaseIntrospection    # isort:skip
+from .operations import DatabaseOperations          # isort:skip
+from .schema import DatabaseSchemaEditor            # isort:skip
+from .utils import utc_tzinfo_factory               # isort:skip
 
 
 class DatabaseWrapper(PostgresDatabaseWrapper):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ setup(
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
     packages=find_packages(),
-    install_requires=['psycopg2'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Framework :: Django',


### PR DESCRIPTION
Users must now manually install either psycopg2 or psycopg2-binary.

fixes #126