### PR TITLE
Use start-single-node command in CI

### DIFF
--- a/teamcity-build/build-teamcity.sh
+++ b/teamcity-build/build-teamcity.sh
@@ -25,7 +25,7 @@ pip3 install .
 wget "https://binaries.cockroachdb.com/cockroach-${VERSION}.linux-amd64.tgz"
 tar -xvf cockroach-${VERSION}*
 cp cockroach-${VERSION}*/cockroach cockroach_exec
-./cockroach_exec start --insecure &
+./cockroach_exec start-single-node --insecure &
 
 cd _django_repo/tests/
 


### PR DESCRIPTION
This sets up the database cluster with slightly different better
parameters that make more sense for running a local single node. E.g.,
it sets the replication factor to 1.