### PR TITLE
ci: add placeholder script for CockroachDB 20.1 build

### DIFF
--- a/teamcity-build/build-teamcity-20.1.sh
+++ b/teamcity-build/build-teamcity-20.1.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -x
+
+# Coming in https://github.com/cockroachdb/django-cockroachdb/pull/91


### PR DESCRIPTION
So we can have green builds in the meantime.