### PR TITLE
build: Make the $repo_root for the container be created before running docker

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -40,7 +40,7 @@ repo_root=$(cd "$(dirname "${0}")" && pwd)
 username=$(id -un)
 uid_gid=$(id -u):$(id -g)
 container_root=${repo_root}/docker_root
-mkdir -p "${container_root}"/{etc,home,home/"${username}"/go/src}
+mkdir -p "${container_root}"/{etc,home,home/"${username}"/go/src} "${container_root}${repo_root}"
 echo "${username}:x:${uid_gid}::/home/${username}:/bin/bash" > "${container_root}/etc/passwd"
 
 exec docker run \


### PR DESCRIPTION
Before:

The $repo_root for inside the container was being created by the docker.

Why change:

When docker creates the $repo_root directory, it uses the `root` user.
We want it to use the user who is running the process instead.

Now:

The "$container_root$repo_root" directory that is mounted into the
container is created before docker is run by the user running docker so
the user will own the directory and be able to delete it afterward.

Fixes: cockroachdb/dev-inf#86