### PR TITLE
use sslmode=verify-full in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ DATABASES = {
         # If connecting with SSL, include the section below, replacing the
         # file paths as appropriate.
         'OPTIONS': {
-            'sslmode': 'require',
+            'sslmode': 'verify-full',
             'sslrootcert': '/certs/ca.crt',
             # Either sslcert and sslkey (below) or PASSWORD (above) is
             # required.


### PR DESCRIPTION
'require' isn't recommended since it can make the cluster susceptible
to MITM and impersonation attacks according to
https://www.cockroachlabs.com/docs/cockroachcloud/authentication.html#node-identity-verification

The initial discussion about this was at https://github.com/cockroachdb/django-cockroachdb/pull/110#pullrequestreview-335374775.