### PR TITLE
drop support for CockroachDB 20.1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,3 @@ No such file or directory`.
      - [overlaps_left (&<), overlaps_right (&>), overlaps_above (&<|),
        overlaps_below (&>|)](https://github.com/cockroachdb/cockroach/issues/57098)
      - [strictly_above (|>>), strictly_below (<<|)](https://github.com/cockroachdb/cockroach/issues/57095)
-
-## Additional limitations in CockroachDB 20.1.x
-
-- The `StdDev` and `Variance` aggregates aren't supported.

--- a/django_cockroachdb/features.py
+++ b/django_cockroachdb/features.py
@@ -1,5 +1,3 @@
-import operator
-
 from django.db.backends.postgresql.features import (
     DatabaseFeatures as PostgresDatabaseFeatures,
 )
@@ -12,7 +10,6 @@ class DatabaseFeatures(PostgresDatabaseFeatures):
     can_clone_databases = False
 
     # Not supported: https://github.com/cockroachdb/cockroach/issues/40476
-    has_select_for_update_nowait = property(operator.attrgetter('is_cockroachdb_20_2'))
     has_select_for_update_skip_locked = False
 
     # Not supported: https://github.com/cockroachdb/cockroach/issues/31632
@@ -20,9 +17,6 @@ class DatabaseFeatures(PostgresDatabaseFeatures):
 
     # Not supported: https://github.com/cockroachdb/cockroach/issues/48307
     supports_deferrable_unique_constraints = False
-
-    # Not supported: https://github.com/cockroachdb/cockroach/issues/9683
-    supports_partial_indexes = property(operator.attrgetter('is_cockroachdb_20_2'))
 
     # There are limitations on having DDL statements in a transaction:
     # https://www.cockroachlabs.com/docs/stable/known-limitations.html#schema-changes-within-transactions
@@ -50,31 +44,15 @@ class DatabaseFeatures(PostgresDatabaseFeatures):
     # PostgreSQL behaves the opposite.
     nulls_order_largest = False
 
-    # Introspection may work but 'CREATE MATERIALIZED VIEW' (required for the
-    # test) isn't implemented: https://github.com/cockroachdb/cockroach/issues/41649
-    can_introspect_materialized_views = property(operator.attrgetter('is_cockroachdb_20_2'))
-
     introspected_big_auto_field_type = 'BigIntegerField'
     introspected_small_auto_field_type = 'BigIntegerField'
-
-    # adding a REFERENCES constraint while also adding a column via ALTER not
-    # supported: https://github.com/cockroachdb/cockroach/issues/32917
-    can_create_inline_fk = property(operator.attrgetter('is_cockroachdb_20_2'))
 
     # This can be removed when CockroachDB adds support for NULL FIRST/LAST:
     # https://github.com/cockroachdb/cockroach/issues/6224
     supports_order_by_nulls_modifier = False
 
-    # CockroachDB stopped creating indexes on foreign keys in 20.2.
-    indexes_foreign_keys = property(operator.attrgetter('is_not_cockroachdb_20_2'))
-
-    @cached_property
-    def is_cockroachdb_20_2(self):
-        return self.connection.cockroachdb_version >= (20, 2)
-
-    @cached_property
-    def is_not_cockroachdb_20_2(self):
-        return self.connection.cockroachdb_version < (20, 2)
+    # CockroachDB doesn't create indexes on foreign keys.
+    indexes_foreign_keys = False
 
     @cached_property
     def django_test_expected_failures(self):
@@ -200,23 +178,6 @@ class DatabaseFeatures(PostgresDatabaseFeatures):
             'model_fields.test_jsonfield.TestQuerying.test_ordering_by_transform',
             'model_fields.test_jsonfield.TestQuerying.test_ordering_grouping_by_key_transform',
         }
-        if not self.connection.features.is_cockroachdb_20_2:
-            expected_failures.update({
-                # stddev/variance functions not supported:
-                # https://github.com/cockroachdb/django-cockroachdb/issues/25
-                'aggregation.test_filter_argument.FilteredAggregateTests.test_filtered_numerical_aggregates',
-                'aggregation_regress.tests.AggregationTests.test_stddev',
-                # Nondeterministic query: https://github.com/cockroachdb/django-cockroachdb/issues/48
-                'queries.tests.SubqueryTests.test_slice_subquery_and_query',
-                # `SHOW TABLES` doesn't distinguish between tables and views.
-                # Both are included regardless of whether inspectdb's
-                # --include-views option is set.
-                'inspectdb.tests.InspectDBTransactionalTests.test_include_views',
-                'introspection.tests.IntrospectionTests.test_table_names_with_views',
-                # excluding null json keys incorrectly returns values where the
-                # key doesn't exist: https://github.com/cockroachdb/cockroach/issues/49143
-                'model_fields.test_jsonfield.TestQuerying.test_none_key_exclude',
-            })
         return expected_failures
 
     django_test_skips = {

--- a/django_cockroachdb/introspection.py
+++ b/django_cockroachdb/introspection.py
@@ -10,11 +10,6 @@ class DatabaseIntrospection(PostgresDatabaseIntrospection):
     data_types_reverse[1184] = 'DateTimeField'  # TIMESTAMPTZ
 
     def get_table_list(self, cursor):
-        if not self.connection.features.is_cockroachdb_20_2:
-            # `type` isn't included in SHOW TABLES.
-            cursor.execute("SELECT table_name FROM [SHOW TABLES]")
-            return [TableInfo(row[0], 't') for row in cursor.fetchall()]
-
         cursor.execute("SELECT table_name, type FROM [SHOW TABLES]")
         # The second TableInfo field is 't' for table or 'v' for view.
         return [TableInfo(row[0], 't' if row[1] == 'table' else 'v') for row in cursor.fetchall()]

--- a/teamcity-build/build-teamcity-20.1.sh
+++ b/teamcity-build/build-teamcity-20.1.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -x
 
-./teamcity-build/build-teamcity.sh "v20.1.13"
+# Not supported

--- a/teamcity-build/build-teamcity-20.2.sh
+++ b/teamcity-build/build-teamcity-20.2.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 set -x
 
-export RUN_GIS_TESTS=1
 ./teamcity-build/build-teamcity.sh "v20.2.6"

--- a/teamcity-build/build-teamcity.sh
+++ b/teamcity-build/build-teamcity.sh
@@ -36,11 +36,6 @@ else
     cp cockroach-${VERSION}*/cockroach cockroach_exec
 fi
 
-# --spatial-lib is an unknown option before CockroachDB 20.2.
-if [[ -z "${RUN_GIS_TESTS}" ]]; then
-    SPATIAL_LIBS=""
-fi
-
 ./cockroach_exec start-single-node --insecure $SPATIAL_LIBS &
 
 cd _django_repo/tests/

--- a/teamcity-build/runtests.py
+++ b/teamcity-build/runtests.py
@@ -158,9 +158,8 @@ for app_name in enabled_test_apps:
     if res != 0:
         shouldFail = True
 
-if os.environ.get('RUN_GIS_TESTS'):
-    res = os.system("python3 runtests.py gis_tests --settings cockroach_gis_settings -v 2")
-    if res != 0:
-        shouldFail = True
+res = os.system("python3 runtests.py gis_tests --settings cockroach_gis_settings -v 2")
+if res != 0:
+    shouldFail = True
 
 sys.exit(1 if shouldFail else 0)


### PR DESCRIPTION
For the upcoming Django 3.2 release (April 1).

See also [What versions of CockroachDB can I use with each version of Django?](https://github.com/cockroachdb/django-cockroachdb/wiki#what-versions-of-cockroachdb-can-i-use-with-each-version-of-django).