### PR TITLE
ci: update to Ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install python3 python3-dev python3-pip build-essential postgresql postgresql-contrib libpq-dev wget git binutils gdal-bin
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install python3 python3-dev python3-pip build-essential postgresql postgresql-contrib libpq-dev wget git binutils gdal-bin libmemcached-dev
 
 # Set the locale
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \

--- a/django_cockroachdb_gis/features.py
+++ b/django_cockroachdb_gis/features.py
@@ -76,6 +76,9 @@ class DatabaseFeatures(CockroachFeatures, PostGISFeatures):
             # data is currently not supported for columns that are part of an
             # index: https://github.com/cockroachdb/cockroach/issues/47636
             'gis_tests.gis_migrations.test_operations.OperationTests.test_alter_geom_field_dim',
+            # This test assumes the GEOS version used by the database and
+            # Django are the same which isn't the case on CI.
+            'gis_tests.geos_tests.test_geos.GEOSTest.test_emptyCollections',
         })
         if not self.connection.features.is_cockroachdb_21_2:
             expected_failures.update({

--- a/docker.sh
+++ b/docker.sh
@@ -21,7 +21,7 @@
 
 set -euo pipefail
 
-image=cockroachdb/cockroach-django-builder:20201123
+image=cockroachdb/cockroach-django-builder:20211210
 
 gopath=$(go env GOPATH)
 gopath0=${gopath%%:*}


### PR DESCRIPTION
Django 4.0 requires Python 3.8+. Ubuntu 20.04 ships with Python 3.8 and Ubuntu 18.04 ships with Python 3.6.