### PR TITLE
ci: mark ALTER COLUMN tests that sometimes fail as expected failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ using back to Cockroach Labs. To disable this, set
    - [changing column type if it's part of an index](https://go.crdb.dev/issue/47636)
    - dropping or changing a table's primary key
    - [indexes on expressions](https://github.com/cockroachdb/cockroach/issues/9682) (Django's [`Index.expressions`](https://docs.djangoproject.com/en/stable/ref/models/indexes/#django.db.models.Index.expressions))
+   - CockroachDB executes `ALTER COLUMN` queries asynchronously which is at
+     odds with Django's assumption that the database is altered before the next
+     migration operation begins. CockroachDB will give an error like
+     `unimplemented: table <...> is currently undergoing a schema change` if a
+     later operation tries to modify the table before the asynchronous query
+     finishes. A future version of CockroachDB [may fix this](https://github.com/cockroachdb/cockroach/issues/47137).
 
 - Unsupported queries:
    - [Mixed type addition in SELECT](https://github.com/cockroachdb/django-cockroachdb/issues/19):

--- a/django_cockroachdb/features.py
+++ b/django_cockroachdb/features.py
@@ -155,6 +155,12 @@ class DatabaseFeatures(PostgresDatabaseFeatures):
             # CockroachDB doesn't support changing the primary key of table.
             'schema.tests.SchemaTests.test_alter_not_unique_field_to_primary_key',
             'schema.tests.SchemaTests.test_primary_key',
+            # ALTER COLUMN fails if previous asynchronous ALTER COLUMN hasn't
+            # finished. https://github.com/cockroachdb/cockroach/issues/47137
+            # These tests only fail sometimes, e.g.
+            # https://github.com/cockroachdb/cockroach/issues/65691
+            'schema.tests.SchemaTests.test_alter_field_db_collation',
+            'schema.tests.SchemaTests.test_alter_field_type_and_db_collation',
             # SmallAutoField doesn't work:
             # https://github.com/cockroachdb/cockroach-django/issues/84
             'bulk_create.tests.BulkCreateTests.test_bulk_insert_nullable_fields',


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/65691