### PR TITLE
README: remove obsolete "no database specified" faq

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,6 @@ If using Kerberos authentication, you can specify a custom service name in
 
 ## FAQ
 
-### Why do I get the error ``psycopg2.errors.InvalidName: no database specified``?
-
-You may need to [create the database](https://www.cockroachlabs.com/docs/stable/create-database.html).
-You can use `cockroach sql --insecure` on the command line to get a SQL prompt.
-
 ## GIS support
 
 To use `django.contrib.gis` with CockroachDB, use


### PR DESCRIPTION
After 931914a427859bfaca7e0dc0de8d996e47a016f3, the error message is:
"database `<name>` does not exist".