### PR TITLE
remove telemetry for Django version

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ To use `django.contrib.gis` with CockroachDB, use
 
 ## Disabling CockroachDB telemetry
 
-By default, CockroachDB 21.1 and later will send the version of Django you are
+By default, CockroachDB sends the version of django-cockroachdb that you're
 using back to Cockroach Labs. To disable this, set
 `DISABLE_COCKROACHDB_TELEMETRY = True` in your Django settings.
 

--- a/django_cockroachdb/base.py
+++ b/django_cockroachdb/base.py
@@ -2,7 +2,6 @@ import os
 import re
 from contextlib import contextmanager
 
-import django
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.functional import cached_property
@@ -70,10 +69,6 @@ class DatabaseWrapper(PostgresDatabaseWrapper):
             not os.environ.get('RUNNING_DJANGOS_TEST_SUITE') == 'true'
         ):
             with self.connection.cursor() as cursor:
-                cursor.execute(
-                    "SELECT crdb_internal.increment_feature_counter(%s)",
-                    ["Django %d.%d" % django.VERSION[:2]]
-                )
                 cursor.execute(
                     "SELECT crdb_internal.increment_feature_counter(%s)",
                     ["django-cockroachdb %s" % django_cockroachdb_version]


### PR DESCRIPTION
The Django version can be inferred from the django-cockroachdb version
(i.e. django-cockroachdb A.B.x requires Django A.B).

Follow up to e79d433107776781cab7a35947aee39ea45831ff.