### PR TITLE
add support for psycopg3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-## 4.2 - Unreleased
+## 4.2 - 2023-04-06
 
 Initial release for Django 4.2.x and CockroachDB 22.1.x and 22.2.x.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 ## Prerequisites
 
-You must install either:
+You must install:
+
+* [psycopg](https://pypi.org/project/psycopg/), which may have some
+ prerequisites [depending on which version you use](https://www.psycopg.org/psycopg3/docs/basic/install.html).
+
+You can also use either:
 
 * [psycopg2](https://pypi.org/project/psycopg2/), which has some
   [prerequisites](https://www.psycopg.org/docs/install.html#prerequisites) of

--- a/django_cockroachdb/__init__.py
+++ b/django_cockroachdb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '4.2a0'
+__version__ = '4.2'
 
 # Check Django compatibility before other imports which may fail if the
 # wrong version of Django is installed.

--- a/django_cockroachdb/base.py
+++ b/django_cockroachdb/base.py
@@ -7,14 +7,12 @@ from django.core.exceptions import ImproperlyConfigured
 from django.utils.functional import cached_property
 
 try:
-    import psycopg2  # noqa
-    import psycopg2.extensions  # noqa
-    import psycopg2.extras  # noqa
-except ImportError as err:
-    raise ImproperlyConfigured(
-        'Error loading psycopg2 module.\n'
-        'Did you install psycopg2 or psycopg2-binary?'
-    ) from err
+    try:
+        import psycopg  # noqa
+    except ImportError:
+        import psycopg2  # noqa
+except ImportError:
+    raise ImproperlyConfigured("Error loading psycopg or psycopg2 module")
 
 from django.db.backends.postgresql.base import (
     DatabaseWrapper as PostgresDatabaseWrapper,

--- a/django_cockroachdb/features.py
+++ b/django_cockroachdb/features.py
@@ -117,10 +117,6 @@ class DatabaseFeatures(PostgresDatabaseFeatures):
             'serializers.test_data.SerializerDataTests.test_yaml_serializer',
             # No sequence for AutoField in CockroachDB.
             'introspection.tests.IntrospectionTests.test_sequence_list',
-            # Unsupported query: unsupported binary operator: <int> / <int>:
-            # https://github.com/cockroachdb/django-cockroachdb/issues/21
-            'expressions.tests.ExpressionOperatorTests.test_lefthand_division',
-            'expressions.tests.ExpressionOperatorTests.test_right_hand_division',
             # CockroachDB doesn't support disabling constraints:
             # https://github.com/cockroachdb/cockroach/issues/19444
             'auth_tests.test_views.UUIDUserTests.test_admin_password_change',
@@ -196,6 +192,63 @@ class DatabaseFeatures(PostgresDatabaseFeatures):
             # https://github.com/cockroachdb/cockroach/issues/73587#issuecomment-988408190
             'aggregation.tests.AggregateTestCase.test_aggregation_default_using_decimal_from_database',
         })
+        if self.uses_server_side_binding:
+            expected_failures.update({
+                # could not determine data type of placeholder:
+                # https://github.com/cockroachdb/cockroach/issues/91396
+                'backends.tests.EscapingChecks.test_parameter_escaping',
+                'backends.tests.EscapingChecksDebug.test_parameter_escaping',
+                'expressions.tests.BasicExpressionsTests.test_annotate_values_filter',
+                'expressions_case.tests.CaseDocumentationExamples.test_lookup_example',
+                'expressions_case.tests.CaseDocumentationExamples.test_simple_example',
+                'expressions_case.tests.CaseExpressionTests.test_aggregation_empty_cases',
+                'expressions_case.tests.CaseExpressionTests.test_annotate',
+                'expressions_case.tests.CaseExpressionTests.test_annotate_exclude',
+                'expressions_case.tests.CaseExpressionTests.test_annotate_values_not_in_order_by',
+                'expressions_case.tests.CaseExpressionTests.test_annotate_with_aggregation_in_condition',
+                'expressions_case.tests.CaseExpressionTests.test_annotate_with_aggregation_in_predicate',
+                'expressions_case.tests.CaseExpressionTests.test_annotate_with_annotation_in_condition',
+                'expressions_case.tests.CaseExpressionTests.test_annotate_with_annotation_in_predicate',
+                'expressions_case.tests.CaseExpressionTests.test_annotate_with_empty_when',
+                'expressions_case.tests.CaseExpressionTests.test_annotate_with_expression_as_condition',
+                'expressions_case.tests.CaseExpressionTests.test_annotate_with_full_when',
+                'expressions_case.tests.CaseExpressionTests.test_annotate_with_join_in_condition',
+                'expressions_case.tests.CaseExpressionTests.test_annotate_with_join_in_predicate',
+                'expressions_case.tests.CaseExpressionTests.test_case_reuse',
+                'expressions_case.tests.CaseExpressionTests.test_combined_q_object',
+                'expressions_case.tests.CaseExpressionTests.test_lookup_different_fields',
+                'expressions_case.tests.CaseExpressionTests.test_lookup_in_condition',
+                'expressions_case.tests.CaseExpressionTests.test_update_generic_ip_address',
+                'lookup.tests.LookupQueryingTests.test_conditional_expression',
+                'ordering.tests.OrderingTests.test_order_by_constant_value',
+                'queries.test_bulk_update.BulkUpdateNoteTests.test_batch_size',
+                'queries.test_bulk_update.BulkUpdateNoteTests.test_multiple_fields',
+                'queries.test_bulk_update.BulkUpdateNoteTests.test_simple',
+                'queries.test_bulk_update.BulkUpdateTests.test_custom_pk',
+                'queries.test_bulk_update.BulkUpdateTests.test_database_routing',
+                'queries.test_bulk_update.BulkUpdateTests.test_database_routing_batch_atomicity',
+                'queries.test_bulk_update.BulkUpdateTests.test_falsey_pk_value',
+                'queries.test_bulk_update.BulkUpdateTests.test_inherited_fields',
+                'queries.test_bulk_update.BulkUpdateTests.test_large_batch',
+                'queries.test_bulk_update.BulkUpdateTests.test_updated_rows_when_passing_duplicates',
+                'queries.test_q.QCheckTests.test_expression',
+                # unsupported binary operator: <interval> / <decimal>
+                'expressions.tests.FTimeDeltaTests.test_durationfield_multiply_divide',
+                # InvalidParameterValue: unsupported binary operator: <int4> / <float>
+                'queries.tests.Ticket23605Tests.test_ticket_23605',
+                # InvalidParameterValue: unsupported binary operator: <int2> + <float>
+                'annotations.tests.NonAggregateAnnotationTestCase.test_combined_annotation_commutative',
+                # incompatible COALESCE expressions: unsupported binary
+                # operator: <decimal> / <float>  (desired <decimal>)
+                'aggregation.tests.AggregateTestCase.test_aggregation_default_passed_another_aggregate',
+            })
+        else:
+            expected_failures.update({
+                # Unsupported query: unsupported binary operator: <int> / <int>:
+                # https://github.com/cockroachdb/django-cockroachdb/issues/21
+                'expressions.tests.ExpressionOperatorTests.test_lefthand_division',
+                'expressions.tests.ExpressionOperatorTests.test_right_hand_division',
+            })
         return expected_failures
 
     @cached_property
@@ -224,7 +277,7 @@ class DatabaseFeatures(PostgresDatabaseFeatures):
                 # output in the logs:
                 # Exception in thread Thread-1:
                 # ...
-                # psycopg2.errors.SerializationFailure: restart transaction:
+                # psycopg.errors.SerializationFailure: restart transaction:
                 # TransactionRetryWithProtoRefreshError: WriteTooOldError: write
                 # at timestamp 1598314405.858850941,0 too old; wrote at
                 # 1598314405.883337663,1

--- a/django_cockroachdb_gis/base.py
+++ b/django_cockroachdb_gis/base.py
@@ -1,3 +1,7 @@
+from django.contrib.gis.db.backends.postgis.base import (
+    DatabaseWrapper as PostGISDatabaseWrapper,
+)
+
 from django_cockroachdb.base import DatabaseWrapper as CockroachDatabaseWrapper
 
 from .features import DatabaseFeatures
@@ -6,8 +10,13 @@ from .operations import DatabaseOperations
 from .schema import DatabaseSchemaEditor
 
 
-class DatabaseWrapper(CockroachDatabaseWrapper):
+class DatabaseWrapper(CockroachDatabaseWrapper, PostGISDatabaseWrapper):
     SchemaEditorClass = DatabaseSchemaEditor
     features_class = DatabaseFeatures
     introspection_class = DatabaseIntrospection
     ops_class = DatabaseOperations
+
+    def __init__(self, *args, **kwargs):
+        # Skip PostGISDatabaseWrapper.__init__() to work around
+        # https://code.djangoproject.com/ticket/34344.
+        CockroachDatabaseWrapper.__init__(self, *args, **kwargs)

--- a/django_cockroachdb_gis/features.py
+++ b/django_cockroachdb_gis/features.py
@@ -37,9 +37,6 @@ class DatabaseFeatures(CockroachFeatures, PostGISFeatures):
             'gis_tests.geoapp.tests.GeoLookupTest.test_relate_lookup',
             # NotSupportedError: this box2d comparison operator is experimental
             'gis_tests.geoapp.tests.GeoLookupTest.test_contains_contained_lookups',
-            # unknown signature: st_dwithin(geography, geometry, decimal) (desired <bool>)
-            # https://github.com/cockroachdb/cockroach/issues/53720
-            'gis_tests.geogapp.tests.GeographyTest.test02_distance_lookup',
             # unknown signature: st_distancespheroid(geometry, geometry, string)
             # https://github.com/cockroachdb/cockroach/issues/48922#issuecomment-693096502
             'gis_tests.distapp.tests.DistanceTest.test_distance_lookups_with_expression_rhs',
@@ -74,4 +71,15 @@ class DatabaseFeatures(CockroachFeatures, PostGISFeatures):
             # https://github.com/cockroachdb/cockroach/issues/47420#issuecomment-969578772
             'gis_tests.gis_migrations.test_operations.OperationTests.test_add_3d_field_opclass',
         })
+        if self.uses_server_side_binding:
+            expected_failures.update({
+                # unknown signature: st_scale(geometry, int, int)
+                'gis_tests.geoapp.test_functions.GISFunctionsTests.test_scale',
+            })
+        else:
+            expected_failures.update({
+                # unknown signature: st_dwithin(geography, geometry, decimal) (desired <bool>)
+                # https://github.com/cockroachdb/cockroach/issues/53720
+                'gis_tests.geogapp.tests.GeographyTest.test02_distance_lookup',
+            })
         return expected_failures

--- a/teamcity-build/build-teamcity-22.1.sh
+++ b/teamcity-build/build-teamcity-22.1.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -x
 
+export USE_PSYCOPG2=1
 ./teamcity-build/build-teamcity.sh "v22.1.18"

--- a/teamcity-build/build-teamcity-22.2-psycopg2.sh
+++ b/teamcity-build/build-teamcity-22.2-psycopg2.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -x
 
-# Not supported
+export USE_PSYCOPG2=1
+./teamcity-build/build-teamcity.sh "v22.2.7"

--- a/teamcity-build/build-teamcity-22.2-server-side-binding.sh
+++ b/teamcity-build/build-teamcity-22.2-server-side-binding.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -x
 
-# Not supported
+export USE_SERVER_SIDE_BINDING=1
+./teamcity-build/build-teamcity.sh "v22.2.7"

--- a/teamcity-build/build-teamcity.sh
+++ b/teamcity-build/build-teamcity.sh
@@ -13,7 +13,11 @@ git clone --depth 1 --single-branch --branch cockroach-4.2.x https://github.com/
 cd _django_repo/tests/
 pip3 install -e ..
 pip3 install -r requirements/py3.txt
-pip3 install psycopg2
+if [[ -z "${USE_PSYCOPG2}" ]]; then
+    pip3 install -r requirements/postgres.txt
+else
+    pip3 install psycopg2
+fi
 cd ../..
 
 # install the django-cockroachdb backend.

--- a/teamcity-build/cockroach_settings.py
+++ b/teamcity-build/cockroach_settings.py
@@ -1,3 +1,5 @@
+import os
+
 DATABASES = {
     'default': {
         'ENGINE': 'django_cockroachdb',
@@ -6,6 +8,7 @@ DATABASES = {
         'PASSWORD': '',
         'HOST': 'localhost',
         'PORT': 26257,
+        'OPTIONS': {},
     },
     'other': {
         'ENGINE': 'django_cockroachdb',
@@ -14,8 +17,13 @@ DATABASES = {
         'PASSWORD': '',
         'HOST': 'localhost',
         'PORT': 26257,
+        'OPTIONS': {},
     },
 }
+if os.environ.get('USE_SERVER_SIDE_BINDING'):
+    DATABASES['default']['OPTIONS']['server_side_binding'] = True
+    DATABASES['other']['OPTIONS']['server_side_binding'] = True
+
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 SECRET_KEY = 'django_tests_secret_key'
 PASSWORD_HASHERS = [


### PR DESCRIPTION
Support is forthcoming in Django 4.2 (https://github.com/django/django/pull/15687).