### PR TITLE
ci: remove GEOSTest.test_emptyCollections() from expected failures

### DIFF
--- a/django_cockroachdb_gis/features.py
+++ b/django_cockroachdb_gis/features.py
@@ -69,9 +69,6 @@ class DatabaseFeatures(CockroachFeatures, PostGISFeatures):
             # data is currently not supported for columns that are part of an
             # index: https://github.com/cockroachdb/cockroach/issues/47636
             'gis_tests.gis_migrations.test_operations.OperationTests.test_alter_geom_field_dim',
-            # This test assumes the GEOS version used by the database and
-            # Django are the same which isn't the case on CI.
-            'gis_tests.geos_tests.test_geos.GEOSTest.test_emptyCollections',
             # 3D opclass not present on CockroachDB:
             # https://github.com/cockroachdb/cockroach/issues/47420#issuecomment-969578772
             'gis_tests.gis_migrations.test_operations.OperationTests.test_add_3d_field_opclass',


### PR DESCRIPTION
Fixed upstream in https://github.com/django/django/commit/863aa7541d30247e7eb7a973ff68a7d36f16dc02