### PR TITLE
dbshell: use sslmode and options from DATABASES['OPTIONS']

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.1.1 - Unreleased
+
+- Made `dbshell` use `sslmode` and `options` from the `'OPTIONS'` part of the
+  `DATABASES` setting.
+
 ## 4.1 - 2022-08-03
 
 Initial release for Django 4.1.x and CockroachDB 21.2.x and 22.1.x.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ DATABASES = {
             # required.
             'sslcert': '/certs/client.myprojectuser.crt',
             'sslkey': '/certs/client.myprojectuser.key',
+            # If applicable
+            'options': '--cluster={routing-id}',
         },
     },
 }


### PR DESCRIPTION
The latest [Cockroach docs for Django](https://www.cockroachlabs.com/docs/stable/connect-to-the-database.html?filters=python&filters=django) advise setting connection information like so:

```
DATABASES = {
    'default': {
        'ENGINE': 'django_cockroachdb',
        'NAME': '{database}',
        'USER': '{username}',
        'PASSWORD': '{password}',
        'HOST': '{host}',
        'PORT': '{port}',
        'OPTIONS': {
            'sslmode': 'verify-full',
            'options': '--cluster={routing-id}'
        },
    },
}
```

This currently doesn't work, as the `OPTIONS` are never passed to the connection string. This pull request addresses that and allows connections to CockroachDB Serverless, that requires a `--cluster` routing key.