### PR TITLE
bump python_requires to 3.10

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ project_urls =
     Tracker = https://github.com/cockroachdb/django-cockroachdb/issues
 
 [options]
-python_requires = >=3.8
+python_requires = >=3.10
 packages = find:
 
 [flake8]


### PR DESCRIPTION
Follow up to 9bb1bb364dc41445a50c6eda18d926c2b628fd8a.