### PR TITLE
Fix Now db function to use statement time rather than transaction time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 5.2.1 - Unreleased
 
 - Confirmed support for CockroachDB 25.2.x (no code changes required).
+- Fixed the ``Now`` database function to use the statement time
+  (``STATEMENT_TIMESTAMP``) rather than the transaction time
+  (``CURRENT_TIMESTAMP``).
 
 ## 5.2 - 2025-04-07
 

--- a/django_cockroachdb/functions.py
+++ b/django_cockroachdb/functions.py
@@ -6,7 +6,7 @@ from django.db.models import (
 from django.db.models.expressions import When
 from django.db.models.functions import (
     ACos, ASin, ATan, ATan2, Cast, Ceil, Coalesce, Collate, Cos, Cot, Degrees,
-    Exp, Floor, JSONArray, JSONObject, Ln, Log, Radians, Round, Sin, Sqrt,
+    Exp, Floor, JSONArray, JSONObject, Ln, Log, Now, Radians, Round, Sin, Sqrt,
     StrIndex, Tan,
 )
 
@@ -79,6 +79,7 @@ def register_functions():
     Collate.as_cockroachdb = collate
     JSONArray.as_cockroachdb = JSONArray.as_postgresql
     JSONObject.as_cockroachdb = JSONObject.as_postgresql
+    Now.as_cockroachdb = Now.as_postgresql
     Round.as_cockroachdb = round_cast
     StrIndex.as_cockroachdb = StrIndex.as_postgresql
     When.as_cockroachdb = when


### PR DESCRIPTION
Detected via a test in Django 6.0.