### PR TITLE
bump DatabaseFeatures.minimum_database_version to 24.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.1.1 - Unreleased
+
+- Bumped ``DatabaseFeatures.minimum_database_version`` to 24.3 (an overlooked
+  omission in 6.1).
+
 ## 6.1 - 2026-08-07
 
 Initial release for Django 6.1.x and CockroachDB 24.3.x, 25.2.x, 25.4.x,

--- a/django_cockroachdb/features.py
+++ b/django_cockroachdb/features.py
@@ -5,7 +5,7 @@ from django.utils.functional import cached_property
 
 
 class DatabaseFeatures(PostgresDatabaseFeatures):
-    minimum_database_version = (24, 1)
+    minimum_database_version = (24, 3)
 
     # Cloning databases doesn't speed up tests.
     # https://github.com/cockroachdb/django-cockroachdb/issues/206


### PR DESCRIPTION
An omission in ac3a457c253889d2594b1cc1df2ee0ad1cac9aea.